### PR TITLE
Update documentation build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "compile": "babel src --out-dir lib",
     "prepublish": "npm run compile",
     "postpublish": "npm run build-docs && npm run publish-docs",
-    "build-docs": "export NAME=`npm view . name`; export VERSION=`npm view . version`; documentation readme ./src/index.js --name $NAME --project-version $VERSION --readme-file ./README.md -s $NAME",
+    "build-docs": "NAME=\"${NAME:-$npm_package_name}\" VERSION=\"${VERSION:-$npm_package_version}\" && documentation readme ./src/index.js --readme-file ./README.md --project-name ${NAME} --project-version ${VERSION} --section ${NAME} --markdown-toc false",
     "publish-docs": "npm run build-docs && git add ./README.md && git commit -m 'Updated README API Docs' && git push"
   },
   "repository": {
@@ -31,14 +31,14 @@
     "nxus-core": "^4.0.0"
   },
   "devDependencies": {
+    "babel-cli": "^6.9.0",
+    "babel-core": "^6.9.0",
+    "babel-preset-es2015": "^6.9.0",
+    "chai": "^3.5.0",
+    "chai-as-promised": "^5.2.0",
+    "documentation": "^6.1.0",
     "mocha": "^2.2.5",
     "should": "^7.0.2",
-    "sinon": "^1.17.2",
-    "chai": "^3.5.0",
-    "documentation": "^4.0.0-beta9",
-    "chai-as-promised": "^5.2.0",
-    "babel-preset-es2015": "^6.9.0",
-    "babel-cli": "^6.9.0",
-    "babel-core": "^6.9.0"
+    "sinon": "^1.17.2"
   }
 }


### PR DESCRIPTION
Updated `devDependencies` to use more current version of `documentation` (`^6.1.0`). Changed `build-docs` script to refer to the name and version from `package.json`, rather than retrieving them with `npm view`; also updated option names to match newer `documentation`.

Suggest we roll these changes into other nxus modules as we update them.